### PR TITLE
feat: add deps as an acceptable scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ And valid scopes are
 - models
 - streams
 - requirements
+- deps
 ```
 
-So the following, for example, are allowed PR titles:
+A valid PR title has the form `<type><(optional:scope): <description>`, So the following, for example, are allowed PR titles:
 
 `feat: add Polish language`
 
 `fix(requirements): bump pydantic to version x.x.x`
+
+`chore(deps): bump the general-updates group with 6 updates`
 
 See https://www.conventionalcommits.org/en/v1.0.0/#specification for more information

--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,7 @@ runs:
           models
           streams
           requirements
+          deps
         ## Configure that a scope must always be provided.
         requireScope: false
         ## Configure which scopes (newline delimited) are disallowed in PR


### PR DESCRIPTION
## Description

Adds `deps` as an allowed scope, to enable PRs [like these](https://github.com/aruba-uxi/kai/pull/396) to pass CI tests automatically

