### PR TITLE
fix: remove deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,11 @@ And valid scopes are
 - models
 - streams
 - requirements
-- deps
 ```
 
-A valid PR title has the form `<type><(optional:scope): <description>`, So the following, for example, are allowed PR titles:
+A valid PR title has the form `<type><(optional:scope)>: <description>`, So the following, for example, are allowed PR titles:
 
-`feat: add Polish language`
-
-`fix(requirements): bump pydantic to version x.x.x`
-
-`chore(deps): bump the general-updates group with 6 updates`
+- `feat: add Polish language`
+- `fix(requirements): bump pydantic to version x.x.x`
 
 See https://www.conventionalcommits.org/en/v1.0.0/#specification for more information

--- a/action.yaml
+++ b/action.yaml
@@ -33,7 +33,6 @@ runs:
           models
           streams
           requirements
-          deps
         ## Configure that a scope must always be provided.
         requireScope: false
         ## Configure which scopes (newline delimited) are disallowed in PR


### PR DESCRIPTION
## Description

Remove `deps` as an allowed scope. We rather want to update the relevant PR's to create titles that go like `fix(requirements): xxx` for dependency bumps, as this gets us a version bump too.
